### PR TITLE
Make .asc files world-readable

### DIFF
--- a/sort-artifacts
+++ b/sort-artifacts
@@ -156,6 +156,7 @@ class Tarball(object):
                     'GPG signature not created properly for file {0}'
                     .format(path))
             if os.path.exists(ascpath):
+                os.chmod(ascpath, 0o644)
                 shutil.move(ascpath, self.dest)
         return self.dest
 


### PR DESCRIPTION
Our nightly-publishing scripts are failing to publish .asc files because they can't read them -- those files have 0600 permissions.  This commit changes them to 0644.